### PR TITLE
Slipometer v0.0.1

### DIFF
--- a/python/slipometer/README.md
+++ b/python/slipometer/README.md
@@ -1,0 +1,14 @@
+# template
+
+tempalte is a sample Assetto Corsa app that does nothing! It serves as a starting point to create new apps. There exists a template script that allows you to create your starting app
+
+## Usage
+from TurnRightToGoLeft directory:
+```
+./template/template.sh [YOUR_APP_NAME]
+```
+
+3 Speed Gauges in KM/H. These let you see your max speed at the end of the straight, current speed, and minimum speed through a corner to help you bring down those laptimes!
+
+## Inspiration
+https://www.reddit.com/r/formula1/comments/g9tnm3/michael_schumacher_wanted_three_digital/?context=3

--- a/python/slipometer/slipometer.py
+++ b/python/slipometer/slipometer.py
@@ -1,0 +1,170 @@
+import sys
+import ac
+import acsys
+import os
+import platform
+
+if platform.architecture()[0] == "64bit":
+    libdir = 'third_party/lib64'
+else:
+    libdir = 'third_party/lib'
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), libdir))
+os.environ['PATH'] = os.environ['PATH'] + ";."
+
+from third_party.sim_info import SimInfo
+
+appName = "slipometer"
+
+#text labels
+label_slip_ratio_FL = None
+label_slip_ratio_FR = None
+label_slip_ratio_RL = None
+label_slip_ratio_RR = None
+
+#window size settings
+size_mult = 1.0
+window_height = 200*size_mult
+window_width = 100 * size_mult
+
+#height 0-(.5*height) front boxes
+#height (.5*height)-(1.0*heihgt) rear boxes
+
+#width 0-(.5*width) left boxes
+#width (.5*width)-(1.0*width) right boxes
+
+#car data
+slip_ratio_FL = 0.0
+slip_ratio_FR = 0.0
+slip_ratio_RL = 0.0
+slip_ratio_RR = 0.0
+tc_setting = 1
+abs_setting = 1
+
+
+def log_to_file(msg):
+    ac.log(appName + ": " + str(msg))
+
+def log_to_console(msg):
+    ac.console(appName + ": " + str(msg))
+
+def log(msg):
+    ac.log(appName + ": " + str(msg))
+    ac.console(appName + ": " + str(msg))
+
+def acMain(ac_version):
+    global label_slip_ratio_FL, label_slip_ratio_FR, label_slip_ratio_RL, label_slip_ratio_RR
+    appWindow = ac.newApp(appName)
+    ac.setSize(appWindow, window_width, window_height)
+    log("SEM SEM SEM SEM")
+
+    #create lables
+    label_slip_ratio_FL = ac.addLabel(appWindow, "fl")
+    label_slip_ratio_FR = ac.addLabel(appWindow, "fr")
+    label_slip_ratio_RL = ac.addLabel(appWindow, "rl")
+    label_slip_ratio_RR = ac.addLabel(appWindow, "rr")
+
+    #align text center
+    ac.setFontAlignment(label_slip_ratio_FL, "right")
+    ac.setFontAlignment(label_slip_ratio_FR, "left")
+    ac.setFontAlignment(label_slip_ratio_RL, "right")
+    ac.setFontAlignment(label_slip_ratio_RR, "left")
+
+    #positions
+    ac.setPosition(label_slip_ratio_FL, .33*window_width, .25*window_height)
+    ac.setPosition(label_slip_ratio_FR, .66*window_width, .25*window_height)
+    ac.setPosition(label_slip_ratio_RL, .33*window_width, .75*window_height)
+    ac.setPosition(label_slip_ratio_RR, .66*window_width, .75*window_height)
+
+   
+    #run after every acUpdate, after every data point comes in
+    ac.addRenderCallback(appWindow, onFormRender)
+
+    return appName
+
+
+def draw_box(x, y, width, height):
+    """
+    Draws a box using the draw() function with the given x, y coordinates,
+    width, and height.
+    """
+    ac.glColor3f(0,1,0)
+    ac.glQuad(x, y, width, 1)  # Top edge
+    ac.glQuad(x, y + height - 1, width, 1)  # Bottom edge
+    ac.glQuad(x, y, 1, height)  # Left edge
+    ac.glQuad(x + width - 1, y, 1, height)  # Right edge
+    ac.glColor3f(0,0,1)
+
+def acUpdate(deltaT):
+    global slip_ratio_FL, slip_ratio_FR, slip_ratio_RL, slip_ratio_RR, tc_setting, abs_setting
+    siminfo = SimInfo()
+
+    slip_ratio_FL, slip_ratio_FR, slip_ratio_RL, slip_ratio_RR = ac.getCarState(0, acsys.CS.SlipRatio)
+    if abs(slip_ratio_FL) < 0.01:
+        slip_ratio_FL = 0
+    if abs(slip_ratio_FR) < 0.01:
+        slip_ratio_FR = 0
+    if abs(slip_ratio_RL) < 0.01:
+        slip_ratio_RL = 0
+    if abs(slip_ratio_RR) < 0.01:
+        slip_ratio_RR = 0
+
+    tc_setting = float(siminfo.physics.tc)
+    abs_setting = float(siminfo.physics.abs)
+
+
+    siminfo.close()
+
+
+def render_tyre_box(x, y, slip, margin=2):
+    """
+    Draws a box, and fills it if needed
+    """
+    draw_box(int(x+margin), int(y+margin), int((.5*window_width)-margin), int((.5*window_height)-margin))
+    #need to check if this wheel is slippin
+    if tc_setting < slip:
+        ac.glColor3f(1,1,1)
+        ac.glQuad(int(x+margin), int(y+margin), int((.5*window_width)-margin), int((.5*window_height)-margin))
+    elif -1*abs_setting > slip:
+        ac.glColor3f(1,1,1)
+        ac.glQuad(int(x+margin), int(y+margin), int((.5*window_width)-margin), int((.5*window_height)-margin))
+    else:
+        if slip > 0:
+            #percentage to tc activation
+            slip_perc = slip/tc_setting
+            if slip_perc > 1:
+                slip_perc = 1
+            ac.glColor3f(1,0,0)
+            ac.glQuad(x+margin, y+(.5*window_height)-(slip_perc*(.5*window_height))+margin, ((.5*window_width)-margin), (slip_perc*(.5*window_height))-margin)
+        elif slip < 0:
+            slip_perc = (-1*slip)/tc_setting
+            if slip_perc > 1:
+                slip_perc = 1
+            ac.glColor3f(0,0,1)
+            ac.glQuad(x+margin, y+margin, (.5*window_width)-margin, slip_perc*(.5*window_height)-margin)
+
+
+    #if not breakin no limits
+    #else:
+
+    #else if negative ELIF IMPORTANT!!
+    #height = perc to limit slip/abs_settign
+    #glquad(x, top, width, perc of box height)
+    #glquad(x, y, width, perc*(.5*height)
+
+
+    
+def onFormRender(deltaT):
+    margin = 2
+
+    #draw FL box
+    render_tyre_box(0, 0, slip_ratio_FL)
+    render_tyre_box((.5*window_width), 0, slip_ratio_FR)
+    render_tyre_box(0, (.5*window_height), slip_ratio_RL)
+    render_tyre_box((.5*window_width), (.5*window_height), slip_ratio_RR)
+
+    #set labels
+    ac.setText(label_slip_ratio_FL, str(round(slip_ratio_FL,2)))
+    ac.setText(label_slip_ratio_FR, str(round(slip_ratio_FR,2)))
+    ac.setText(label_slip_ratio_RL, str(round(slip_ratio_RL,2)))
+    ac.setText(label_slip_ratio_RR, str(round(slip_ratio_RR,2)))
+

--- a/python/slipometer/third_party/sim_info.py
+++ b/python/slipometer/third_party/sim_info.py
@@ -1,0 +1,243 @@
+"""
+Assetto Corsa shared memory for Python applications
+
+_ctypes.pyd must be somewhere in sys.path, because AC doesn't include all Python binaries.
+
+Usage. Let's say you have following folder structure::
+
+    some_app
+        DLLs
+            _ctypes.pyd
+        some_app.py
+
+some_app.py::
+
+    import os
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'DLLs'))
+
+    from sim_info import info
+
+    print(info.graphics.tyreCompound, info.physics.rpms, info.static.playerNick)
+
+
+Do whatever you want with this code!
+WBR, Rombik :)
+"""
+import mmap
+import functools
+import ctypes
+from ctypes import c_int32, c_float, c_wchar
+
+AC_STATUS = c_int32
+AC_OFF = 0
+AC_REPLAY = 1
+AC_LIVE = 2
+AC_PAUSE = 3
+AC_SESSION_TYPE = c_int32
+AC_UNKNOWN = -1
+AC_PRACTICE = 0
+AC_QUALIFY = 1
+AC_RACE = 2
+AC_HOTLAP = 3
+AC_TIME_ATTACK = 4
+AC_DRIFT = 5
+AC_DRAG = 6
+AC_FLAG_TYPE = c_int32
+AC_NO_FLAG = 0
+AC_BLUE_FLAG = 1
+AC_YELLOW_FLAG = 2
+AC_BLACK_FLAG = 3
+AC_WHITE_FLAG = 4
+AC_CHECKERED_FLAG = 5
+AC_PENALTY_FLAG = 6
+
+class SPageFilePhysics(ctypes.Structure):
+	_pack_ = 4
+	_fields_ = [
+		('packetId', c_int32),
+		('gas', c_float),
+		('brake', c_float),
+		('fuel', c_float),
+		('gear', c_int32),
+		('rpms', c_int32),
+		('steerAngle', c_float),
+		('speedKmh', c_float),
+		('velocity', c_float * 3),
+		('accG', c_float * 3),
+		('wheelSlip', c_float * 4),
+		('wheelLoad', c_float * 4),
+		('wheelsPressure', c_float * 4),
+		('wheelAngularSpeed', c_float * 4),
+		('tyreWear', c_float * 4),
+		('tyreDirtyLevel', c_float * 4),
+		('tyreCoreTemperature', c_float * 4),
+		('camberRAD', c_float * 4),
+		('suspensionTravel', c_float * 4),
+		('drs', c_float),
+		('tc', c_float),
+		('heading', c_float),
+		('pitch', c_float),
+		('roll', c_float),
+		('cgHeight', c_float),
+		('carDamage', c_float * 5),
+		('numberOfTyresOut', c_int32),
+		('pitLimiterOn', c_int32),
+		('abs', c_float),
+		('kersCharge', c_float),
+		('kersInput', c_float),
+		('autoShifterOn', c_int32),
+		('rideHeight', c_float * 2),
+		('turboBoost', c_float),
+		('ballast', c_float),
+		('airDensity', c_float),
+		('airTemp', c_float),
+		('roadTemp', c_float),
+		('localAngularVel', c_float * 3),
+		('finalFF', c_float),
+		('performanceMeter', c_float),
+		('engineBrake', c_int32),
+		('ersRecoveryLevel', c_int32),
+		('ersPowerLevel', c_int32),
+		('ersHeatCharging', c_int32),
+		('ersIsCharging', c_int32),
+		('kersCurrentKJ', c_float),
+		('drsAvailable', c_int32),
+		('drsEnabled', c_int32),
+		('brakeTemp', c_float * 4),
+		('clutch', c_float),
+		('tyreTempI', c_float * 4),
+		('tyreTempM', c_float * 4),
+		('tyreTempO', c_float * 4),
+		('isAIControlled', c_int32),
+		('tyreContactPoint', c_float * 4 * 3),
+		('tyreContactNormal', c_float * 4 * 3),
+		('tyreContactHeading', c_float * 4 * 3),
+		('brakeBias', c_float),
+		('localVelocity', c_float * 3),
+
+	]
+
+class SPageFileGraphic(ctypes.Structure):
+	_pack_ = 4
+	_fields_ = [
+		('packetId', c_int32),
+		('status', AC_STATUS),
+		('session', AC_SESSION_TYPE),
+		('currentTime', c_wchar * 15),
+		('lastTime', c_wchar * 15),
+		('bestTime', c_wchar * 15),
+		('split', c_wchar * 15),
+		('completedLaps', c_int32),
+		('position', c_int32),
+		('iCurrentTime', c_int32),
+		('iLastTime', c_int32),
+		('iBestTime', c_int32),
+		('sessionTimeLeft', c_float),
+		('distanceTraveled', c_float),
+		('isInPit', c_int32),
+		('currentSectorIndex', c_int32),
+		('lastSectorTime', c_int32),
+		('numberOfLaps', c_int32),
+		('tyreCompound', c_wchar * 33),
+		('replayTimeMultiplier', c_float),
+		('normalizedCarPosition', c_float),
+		('carCoordinates', c_float * 3),
+		('penaltyTime', c_float),
+		('flag', AC_FLAG_TYPE),
+		('idealLineOn', c_int32),
+		('isInPitLine', c_int32),
+		('surfaceGrip', c_float),
+		('mandatoryPitDone', c_int32),
+		('windSpeed', c_float),
+		('windDirection', c_float),
+
+	]
+
+class SPageFileStatic(ctypes.Structure):
+	_pack_ = 4
+	_fields_ = [
+		('_smVersion', c_wchar * 15),
+		('_acVersion', c_wchar * 15),
+		('numberOfSessions', c_int32),
+		('numCars', c_int32),
+		('carModel', c_wchar * 33),
+		('track', c_wchar * 33),
+		('playerName', c_wchar * 33),
+		('playerSurname', c_wchar * 33),
+		('playerNick', c_wchar * 33),
+		('sectorCount', c_int32),
+		('maxTorque', c_float),
+		('maxPower', c_float),
+		('maxRpm', c_int32),
+		('maxFuel', c_float),
+		('suspensionMaxTravel', c_float * 4),
+		('tyreRadius', c_float * 4),
+		('maxTurboBoost', c_float),
+		('airTemp', c_float),
+		('roadTemp', c_float),
+		('penaltiesEnabled', c_int32),
+		('aidFuelRate', c_float),
+		('aidTireRate', c_float),
+		('aidMechanicalDamage', c_float),
+		('aidAllowTyreBlankets', c_int32),
+		('aidStability', c_float),
+		('aidAutoClutch', c_int32),
+		('aidAutoBlip', c_int32),
+		('hasDRS', c_int32),
+		('hasERS', c_int32),
+		('hasKERS', c_int32),
+		('kersMaxJ', c_float),
+		('engineBrakeSettingsCount', c_int32),
+		('ersPowerControllerCount', c_int32),
+		('trackSPlineLength', c_float),
+		('trackConfiguration', c_wchar * 33),
+		('ersMaxJ', c_float),
+		('isTimedRace', c_int32),
+		('hasExtraLap', c_int32),
+		('carSkin', c_wchar * 33),
+		('reversedGridPositions', c_int32),
+		('pitWindowStart', c_int32),
+		('pitWindowEnd', c_int32),
+
+	]
+
+class SimInfo:
+	def __init__(self):
+		self._acpmf_physics = mmap.mmap(0, ctypes.sizeof(SPageFilePhysics), "acpmf_physics")
+		self._acpmf_graphics = mmap.mmap(0, ctypes.sizeof(SPageFileGraphic), "acpmf_graphics")
+		self._acpmf_static = mmap.mmap(0, ctypes.sizeof(SPageFileStatic), "acpmf_static")
+		self.physics = SPageFilePhysics.from_buffer(self._acpmf_physics)
+		self.graphics = SPageFileGraphic.from_buffer(self._acpmf_graphics)
+		self.static = SPageFileStatic.from_buffer(self._acpmf_static)
+
+	def close(self):
+		self._acpmf_physics.close()
+		self._acpmf_graphics.close()
+		self._acpmf_static.close()
+
+	def __del__(self):
+		self.close()
+
+info = SimInfo()
+
+def demo():
+	import time
+
+	for _ in range(400):
+		print(info.static.track, info.graphics.tyreCompound, info.graphics.currentTime,
+			  info.physics.rpms, info.graphics.currentTime, info.static.maxRpm, list(info.physics.tyreWear))
+		time.sleep(0.1)
+
+def do_test():
+	for struct in info.static, info.graphics, info.physics:
+		print(struct.__class__.__name__)
+		for field, type_spec in struct._fields_:
+			value = getattr(struct, field)
+			if not isinstance(value, (str, float, int)):
+				value = list(value)
+			print(" {} -> {} {}".format(field, type(value), value))
+
+if __name__ == '__main__':
+	do_test()
+	demo()


### PR DESCRIPTION
Slipometer helps measure wheel slip in both acceleration and deceleration helping to identify when TC/ABS are kicking in. It can help dial brake bias, diff settings, and identify loss of power from TC. 

Possible Issues
1. Incorrect display at high (open) TC/ABS levels
2. Manual checking / misinterpretation of telemetry data being used to calculate electronics firing.
3. Text values getting hidden by draw
4. Scaling untested
5. Title being hid. 